### PR TITLE
Use ARGF instead of STDIN, and avoid unnecessary array allocations

### DIFF
--- a/tin-whistle.cr
+++ b/tin-whistle.cr
@@ -17,7 +17,7 @@ class TinWhistle
   def print
     # print out the name of the note
     @input.each do |note|
-      char = if ['f', 'F', 'c', 'C'].includes?(note)
+      char = if {'f', 'F', 'c', 'C'}.includes?(note)
         "#{note}#"
       else
         note.to_s
@@ -29,7 +29,7 @@ class TinWhistle
 
     # print a "." if the note is in the upper octave
     @input.each do |note|
-      char = if ('A'..'Z').to_a.includes?(note)
+      char = if ('A'..'Z').includes?(note)
         '.'
       elsif note == '|'
         '|'
@@ -60,5 +60,5 @@ class TinWhistle
   end
 end
 
-notes = STDIN.read.lines.reject { |line| line =~ /^T:/ }.join.chars
+notes = ARGF.read.lines.reject { |line| line =~ /^T:/ }.join.chars
 TinWhistle.new(notes).print


### PR DESCRIPTION
Hi!

Really cute project! I like it!

This pull requests contains two things:
1. Use ARGF instead of STDIN. This allows you to pass the file as an argument (`./tin-whistle example.abc`) as well as reading from STDIN if there are no arguments.
2. Avoid creating arrays, which allocate memory. In the first case I use a tuple (memory lives in the stack, compiler can optimize better). In the second case the `to_a` call is unnecessary.

The optimizations in point 2 probably won't make any difference, but now that you know them you can be aware of them in bigger projects ;-)
